### PR TITLE
Only show failed tests

### DIFF
--- a/temper.h
+++ b/temper.h
@@ -1397,7 +1397,7 @@ void TemperSetupInternal( void ) {
 		if ( !callbacks->RunTestThread )		{ callbacks->RunTestThread = TemperRunTestThreadInternal; }
 		if ( !callbacks->OnAllTestsFinished )	{ callbacks->OnAllTestsFinished = TemperOnAllTestsFinishedInternal; }
 
-		// platform-specific callbacks
+		// platform-specific
 #if defined( _WIN32 )
 		if ( !callbacks->Dup )					{ callbacks->Dup = _dup; }
 		if ( !callbacks->Dup2 )					{ callbacks->Dup2 = _dup2; }

--- a/temper.h
+++ b/temper.h
@@ -1380,17 +1380,6 @@ void TemperSetupInternal( void ) {
 		if ( !callbacks->VSNPrintf )			{ callbacks->VSNPrintf = vsnprintf; }
 		if ( !callbacks->FFlush )				{ callbacks->FFlush = fflush; }
 		if ( !callbacks->FOpen )				{ callbacks->FOpen = fopen; }
-#if defined( _WIN32 )
-		if ( !callbacks->Dup )					{ callbacks->Dup = _dup; }
-		if ( !callbacks->Dup2 )					{ callbacks->Dup2 = _dup2; }
-		if ( !callbacks->Fileno )				{ callbacks->Fileno = _fileno; }
-#elif defined( __APPLE__ ) || defined( __linux__ )	// defined( _WIN32 )
-		if ( !callbacks->Dup )					{ callbacks->Dup = dup; }
-		if ( !callbacks->Dup2 )					{ callbacks->Dup2 = dup2; }
-		if ( !callbacks->Fileno )				{ callbacks->Fileno = fileno; }
-#else	// defined( _WIN32 )
-#error Uncrecognised platform.  It appears Temper does not support it.  If you think this is a bug, please submit an issue at https://github.com/dangmoody/Temper/issues
-#endif	// defined( _WIN32 )
 		if ( !callbacks->Strcmp )				{ callbacks->Strcmp = strcmp; }
 		if ( !callbacks->StringContains )		{ callbacks->StringContains = TemperStringContainsInternal; }
 		if ( !callbacks->GetTimestamp )			{ callbacks->GetTimestamp = TemperGetTimestampInternal; }
@@ -1407,6 +1396,19 @@ void TemperSetupInternal( void ) {
 		if ( !callbacks->OnAfterTest )			{ callbacks->OnAfterTest = TemperOnAfterTestInternal; }
 		if ( !callbacks->RunTestThread )		{ callbacks->RunTestThread = TemperRunTestThreadInternal; }
 		if ( !callbacks->OnAllTestsFinished )	{ callbacks->OnAllTestsFinished = TemperOnAllTestsFinishedInternal; }
+
+		// platform-specific callbacks
+#if defined( _WIN32 )
+		if ( !callbacks->Dup )					{ callbacks->Dup = _dup; }
+		if ( !callbacks->Dup2 )					{ callbacks->Dup2 = _dup2; }
+		if ( !callbacks->Fileno )				{ callbacks->Fileno = _fileno; }
+#elif defined( __APPLE__ ) || defined( __linux__ )	// defined( _WIN32 )
+		if ( !callbacks->Dup )					{ callbacks->Dup = dup; }
+		if ( !callbacks->Dup2 )					{ callbacks->Dup2 = dup2; }
+		if ( !callbacks->Fileno )				{ callbacks->Fileno = fileno; }
+#else	// defined( _WIN32 )
+#error Uncrecognised platform.  It appears Temper does not support it.  If you think this is a bug, please submit an issue at https://github.com/dangmoody/Temper/issues
+#endif	// defined( _WIN32 )
 	}
 
 #ifdef _WIN32

--- a/tests/automation_c/automation_c.c
+++ b/tests/automation_c/automation_c.c
@@ -620,13 +620,13 @@ CONDITION_TEST( CheckNotDoubleSEqual_ValuesAroundUpperLowerBoundaries_ErrorCount
 //----------------------------------------------------------
 
 RESULT_DEPENDANT_TEST( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsTest, TEMPER_FLAG_SHOULD_RUN ) {
-	g_temperTestContext.flags |= TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
+	g_temperTestContext.flags |= TEMPERDEV_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
 	TEMPER_CHECK_TRUE_QM(false, "Expected error 3 - We expect this test to quit now.\n");
 	testAbortTestNumberWeNeverExpectSet = THE_ABORT_TEST_FAILURE_NUMBER;
 }
 
 TEMPER_TEST( CheckAndCleanResults_9, TEMPER_FLAG_SHOULD_RUN ) {
-	g_temperTestContext.flags &= ~TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
+	g_temperTestContext.flags &= ~TEMPERDEV_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
 	if ( AssertResults( 0, 1, 1, 1, 0 ) ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_QUIT_ATTEMPT );
 	}
@@ -636,7 +636,7 @@ TEMPER_TEST( CheckAndCleanResults_9, TEMPER_FLAG_SHOULD_RUN ) {
 }
 
 RESULT_DEPDENDANT_TEST_PARAMETRIC( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsParametricTest, const bool check ) {
-	g_temperTestContext.flags |= TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
+	g_temperTestContext.flags |= TEMPERDEV_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
 	TEMPER_CHECK_TRUE_QM( check, "We expect this test to quit.\n" );
 	testAbortTestNumberWeNeverExpectSet = THE_ABORT_TEST_FAILURE_NUMBER;
 }
@@ -644,7 +644,7 @@ RESULT_DEPDENDANT_TEST_PARAMETRIC( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbo
 TEMPER_INVOKE_PARAMETRIC_TEST( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsParametricTest, false );
 
 TEMPER_TEST( CheckAndCleanResults_10, TEMPER_FLAG_SHOULD_RUN ) {
-	g_temperTestContext.flags &= ~TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
+	g_temperTestContext.flags &= ~TEMPERDEV_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
 	if( AssertResults( 0, 1, 1, 1, 0 ) ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_QUIT_ATTEMPT );
 	}

--- a/tests/automation_c/automation_c.c
+++ b/tests/automation_c/automation_c.c
@@ -620,13 +620,13 @@ CONDITION_TEST( CheckNotDoubleSEqual_ValuesAroundUpperLowerBoundaries_ErrorCount
 //----------------------------------------------------------
 
 RESULT_DEPENDANT_TEST( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsTest, TEMPER_FLAG_SHOULD_RUN ) {
-	g_temperTestContext.negateQuitAttempts = true;
+	g_temperTestContext.flags |= TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
 	TEMPER_CHECK_TRUE_QM(false, "Expected error 3 - We expect this test to quit now.\n");
 	testAbortTestNumberWeNeverExpectSet = THE_ABORT_TEST_FAILURE_NUMBER;
 }
 
 TEMPER_TEST( CheckAndCleanResults_9, TEMPER_FLAG_SHOULD_RUN ) {
-	g_temperTestContext.negateQuitAttempts = false; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
+	g_temperTestContext.flags &= ~TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
 	if ( AssertResults( 0, 1, 1, 1, 0 ) ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_QUIT_ATTEMPT );
 	}
@@ -636,7 +636,7 @@ TEMPER_TEST( CheckAndCleanResults_9, TEMPER_FLAG_SHOULD_RUN ) {
 }
 
 RESULT_DEPDENDANT_TEST_PARAMETRIC( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsParametricTest, const bool check ) {
-	g_temperTestContext.negateQuitAttempts = true;
+	g_temperTestContext.flags |= TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
 	TEMPER_CHECK_TRUE_QM( check, "We expect this test to quit.\n" );
 	testAbortTestNumberWeNeverExpectSet = THE_ABORT_TEST_FAILURE_NUMBER;
 }
@@ -644,7 +644,7 @@ RESULT_DEPDENDANT_TEST_PARAMETRIC( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbo
 TEMPER_INVOKE_PARAMETRIC_TEST( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsParametricTest, false );
 
 TEMPER_TEST( CheckAndCleanResults_10, TEMPER_FLAG_SHOULD_RUN ) {
-	g_temperTestContext.negateQuitAttempts = false; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
+	g_temperTestContext.flags &= ~TEMPER_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
 	if( AssertResults( 0, 1, 1, 1, 0 ) ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_QUIT_ATTEMPT );
 	}

--- a/tests/automation_c/automation_c.c
+++ b/tests/automation_c/automation_c.c
@@ -5,6 +5,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #pragma clang diagnostic ignored "-Wpadded"
+#pragma clang diagnostic ignored "-Wformat-security"
+#pragma clang diagnostic ignored "-Wdeclaration-after-statement"
 #endif
 
 //----------------------------------------------------------
@@ -124,7 +126,7 @@ static void AbsolvePreviousTest( const automationAccountFor_t claim ) {
 		g_temperTestContext.testsPassed += 1;
 		g_temperTestContext.testsSkipped -= 1;
 		g_temperTestContext.callbacks.Log( stdout, "Absolved previous skip.\n" );
-	}else if ( claim == ACCOUNT_FOR_QUIT_ATTEMPT ) {
+	} else if ( claim == ACCOUNT_FOR_QUIT_ATTEMPT ) {
 		TEMPERDEV_ASSERT( g_temperTestContext.testsFailed > 0 );
 		TEMPERDEV_ASSERT( g_temperTestContext.testsAborted > 0 );
 		TEMPERDEV_ASSERT( g_temperTestContext.testsQuit > 0 );
@@ -141,7 +143,7 @@ static void AbsolvePreviousTest( const automationAccountFor_t claim ) {
 //----------------------------------------------------------
 
 static void PassOrFailTest(const bool AllowPass, const char* message) {
-	if( AllowPass ) {
+	if ( AllowPass ) {
 		AbsolveTest( true );
 	} else {
 		g_temperTestContext.currentTestErrorCount += 1;
@@ -314,7 +316,7 @@ TEMPER_TEST( CheckAndCleanResults_7, TEMPER_FLAG_SHOULD_RUN ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_ONE_ABORT );
 	}
 
-	TEMPER_CHECK_NOT_EQUAL_M(testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Aborts in tests do not kill threads as the failure number was set.");
+	TEMPER_CHECK_NOT_EQUAL_M( testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Aborts in tests do not kill threads as the failure number was set." );
 	testAbortTestNumberWeNeverExpectSet = 0;
 }
 
@@ -326,11 +328,11 @@ RESULT_DEPDENDANT_TEST_PARAMETRIC( CheckTrue_WhenAbortTriggered_AbortsParametric
 TEMPER_INVOKE_PARAMETRIC_TEST( CheckTrue_WhenAbortTriggered_AbortsParametricTest, false );
 
 TEMPER_TEST( CheckAndCleanResults_8, TEMPER_FLAG_SHOULD_RUN ) {
-	if( AssertResults( 0, 1, 1, 0, 0 ) ) {
+	if ( AssertResults( 0, 1, 1, 0, 0 ) ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_ONE_ABORT );
 	}
 
-	TEMPER_CHECK_NOT_EQUAL_M(testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Aborts in parameteric tests do not kill threads as the failure number was set.");
+	TEMPER_CHECK_NOT_EQUAL_M( testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Aborts in parameteric tests do not kill threads as the failure number was set." );
 	testAbortTestNumberWeNeverExpectSet = 0;
 }
 
@@ -341,7 +343,9 @@ TEMPER_TEST( CheckAndCleanResults_8, TEMPER_FLAG_SHOULD_RUN ) {
 TEMPER_TEST( NoFailuresOrAborts_WhenExitCodeCalculated_ProvidesSuccessCode, TEMPER_FLAG_SHOULD_RUN ) {
 	CaptureTestCounts();
 	ClearTestCounts();
+
 	TEMPER_CHECK_EQUAL_M( TEMPERDEV_EXIT_SUCCESS, TemperCalculateExitCode(), "Expected the success code to be returned for no errors & no aborts" );
+
 	RestoreCapturedTestCounts();
 }
 
@@ -352,8 +356,11 @@ TEMPER_TEST( NoFailuresOrAborts_WhenExitCodeCalculated_ProvidesSuccessCode, TEMP
 TEMPER_TEST( Failures_WhenExitCodeCalculated_ProvidesFailureCode, TEMPER_FLAG_SHOULD_RUN ) {
 	CaptureTestCounts();
 	ClearTestCounts();
+
 	g_temperTestContext.testsFailed = 1;
+
 	TEMPER_CHECK_EQUAL_M( TEMPERDEV_EXIT_FAILURE, TemperCalculateExitCode(), "Expected the failure code to be returned for there being errors" );
+
 	RestoreCapturedTestCounts();
 }
 
@@ -364,8 +371,11 @@ TEMPER_TEST( Failures_WhenExitCodeCalculated_ProvidesFailureCode, TEMPER_FLAG_SH
 TEMPER_TEST( Aborts_WhenExitCodeCalculated_ProvidesFailureCode, TEMPER_FLAG_SHOULD_RUN ) {
 	CaptureTestCounts();
 	ClearTestCounts();
+
 	g_temperTestContext.testsAborted = 1;
+
 	TEMPER_CHECK_EQUAL_M( TEMPERDEV_EXIT_FAILURE, TemperCalculateExitCode(), "Expected the failure code to be returned for there being aborts" );
+
 	RestoreCapturedTestCounts();
 }
 
@@ -621,7 +631,7 @@ CONDITION_TEST( CheckNotDoubleSEqual_ValuesAroundUpperLowerBoundaries_ErrorCount
 
 RESULT_DEPENDANT_TEST( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsTest, TEMPER_FLAG_SHOULD_RUN ) {
 	g_temperTestContext.flags |= TEMPERDEV_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS;
-	TEMPER_CHECK_TRUE_QM(false, "Expected error 3 - We expect this test to quit now.\n");
+	TEMPER_CHECK_TRUE_QM( false, "Expected error 3 - We expect this test to quit now.\n" );
 	testAbortTestNumberWeNeverExpectSet = THE_ABORT_TEST_FAILURE_NUMBER;
 }
 
@@ -631,7 +641,7 @@ TEMPER_TEST( CheckAndCleanResults_9, TEMPER_FLAG_SHOULD_RUN ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_QUIT_ATTEMPT );
 	}
 
-	TEMPER_CHECK_NOT_EQUAL_M(testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Quits do not trigger aborts as the failure number was set.");
+	TEMPER_CHECK_NOT_EQUAL_M( testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Quits do not trigger aborts as the failure number was set." );
 	testAbortTestNumberWeNeverExpectSet = 0;
 }
 
@@ -645,12 +655,36 @@ TEMPER_INVOKE_PARAMETRIC_TEST( CheckTrue_WhenQuitTriggered_QuitInvokedAndAbortsP
 
 TEMPER_TEST( CheckAndCleanResults_10, TEMPER_FLAG_SHOULD_RUN ) {
 	g_temperTestContext.flags &= ~TEMPERDEV_TEST_CONTEXT_FLAG_NEGATE_QUIT_ATTEMPTS; // we do not quit ourselves within this test but if we fail to absolve we will want the quit status of the previous test to fall through and end the run.
-	if( AssertResults( 0, 1, 1, 1, 0 ) ) {
+	if ( AssertResults( 0, 1, 1, 1, 0 ) ) {
 		AbsolvePreviousTest( ACCOUNT_FOR_QUIT_ATTEMPT );
 	}
 
-	TEMPER_CHECK_NOT_EQUAL_M(testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Aborts in parameteric tests do not kill threads as the failure number was set.");
+	TEMPER_CHECK_NOT_EQUAL_M( testAbortTestNumberWeNeverExpectSet, THE_ABORT_TEST_FAILURE_NUMBER, "Aborts in parameteric tests do not kill threads as the failure number was set." );
 	testAbortTestNumberWeNeverExpectSet = 0;
+}
+
+//----------------------------------------------------------
+// > -f TESTS
+//----------------------------------------------------------
+
+// if -f got passed in as a command line arg then nothing gets output to stdout
+TEMPER_TEST( CheckStdoutGetsSuppressedProperly, TEMPER_FLAG_SHOULD_RUN ) {
+	const char* msg = "If you passed -f as a command line arg then you definitely should NOT see this in the console!\n";
+
+	printf( msg );
+
+	TEMPER_CHECK_TRUE_M( true, msg );
+}
+
+// if -f got passed in as a command line arg and the test fails, then we definitely do show it
+TEMPER_TEST( CheckStderrGetsWrittenToProperlyOnTestFail, TEMPER_FLAG_SHOULD_RUN ) {
+	TEMPER_CHECK_TRUE_M( 5 == 9, "If you passed -f as a command line arg then you definitely SHOULD see this in the console!\n" );
+}
+
+TEMPER_TEST( CheckAndCleanResults_11, TEMPER_FLAG_SHOULD_RUN ) {
+	if ( AssertResults( 3, 1, 0, 0, 0 ) ) {
+		AbsolvePreviousTest( ACCOUNT_FOR_ONE_FAILURE );
+	}
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
Add new command line arg `-f` which will only display tests that failed.

Tests that pass will not print anything when this mode is running.